### PR TITLE
Track upstream branches in .gitmodules (for nightly submodule auto-bump)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "parse-en-us"]
 	path = parse-en-us
 	url = https://github.com/VisualText/parse-en-us.git
+	branch = main
 [submodule "nlp-tutorials"]
 	path = nlp-tutorials
 	url = https://github.com/VisualText/nlp-tutorials.git
+	branch = main
 [submodule "nlpfix-analyzers"]
 	path = nlpfix-analyzers
 	url = https://github.com/VisualText/nlpfix-analyzers.git
+	branch = main


### PR DESCRIPTION
Adds `branch =` lines to the VisualText submodules so `git submodule update --remote` follows the correct branch. Prerequisite for the nightly submodule auto-bump workflow. vcpkg is intentionally left untouched (stays pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)