### PR TITLE
Percolation: listen for parse-en-us-release, ping nlp-engine

### DIFF
--- a/.github/workflows/parse-en-us.yml
+++ b/.github/workflows/parse-en-us.yml
@@ -1,11 +1,18 @@
-# Install at: VisualText/analyzers  ->  .github/workflows/update-parse-en-us.yml
+# Install at: VisualText/analyzers  ->  .github/workflows/parse-en-us.yml
 #
-# Mirrors visualtext-files/.github/workflows/update-parse-en-us.yml: a manual
-# (workflow_dispatch) "pull the submodule, version-bump, tag, release" job.
-# The release asset is built and attached IN THIS JOB on purpose: a release
-# created with the default GITHUB_TOKEN does NOT fire the `release: created`
-# event, so the separate Attach-Released-Assets workflow (analyzer.yml) would
-# never run for an auto-release (same issue visualtext-files PR #153 fixed).
+# Pull the parse-en-us submodule, version-bump, tag, release. The release asset
+# is built and attached IN THIS JOB on purpose: a release created with the
+# default GITHUB_TOKEN does NOT fire the `release: created` event, so the
+# separate Attach-Released-Assets workflow (analyzer.yml) would never run for an
+# auto-release (same issue visualtext-files PR #153 fixed).
+#
+# Triggers:
+#   - workflow_dispatch        : run by hand, pick the bump type
+#   - repository_dispatch      : fired by parse-en-us/dispatch-update-parse-en-us.yml
+#                                (event-type parse-en-us-release); bump defaults to patch
+#
+# When the pointer moves, this also pings nlp-engine (event analyzers-release)
+# so the chain continues. That ping needs the shared `CLASSIC_PAT` secret.
 #
 # To track the other submodules too (nlp-tutorials, nlpfix-analyzers), copy
 # this file and change the SUBMODULE path below.
@@ -24,6 +31,8 @@ on:
           - patch
           - minor
           - major
+  repository_dispatch:
+    types: [parse-en-us-release]    # ping sent by parse-en-us/dispatch-update-parse-en-us.yml
 
 permissions:
   contents: write
@@ -62,18 +71,21 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         id: version
         run: |
+          # workflow_dispatch supplies inputs.bump; repository_dispatch does not,
+          # so default to patch on a ping.
+          BUMP="${{ github.event.inputs.bump }}"; BUMP="${BUMP:-patch}"
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
           LATEST=${LATEST:-v0.0.0}
           VER=${LATEST#v}
           IFS='.' read -r MAJ MIN PAT <<< "$VER"
-          case "${{ inputs.bump }}" in
+          case "$BUMP" in
             major) MAJ=$((MAJ+1)); MIN=0; PAT=0 ;;
             minor) MIN=$((MIN+1)); PAT=0 ;;
             patch) PAT=$((PAT+1)) ;;
           esac
           NEW="v$MAJ.$MIN.$PAT"
           echo "tag=$NEW" >> "$GITHUB_OUTPUT"
-          echo "Next version: $NEW (previous: $LATEST)"
+          echo "Next version: $NEW (previous: $LATEST, bump: $BUMP)"
 
       - name: Commit and tag
         if: steps.update.outputs.changed == 'true'
@@ -107,6 +119,17 @@ jobs:
 
             Submodule bumped from `${{ steps.update.outputs.old_sha }}` to `${{ steps.update.outputs.new_sha }}`.
 
+      # Continue the chain: tell nlp-engine that analyzers moved.
+      - name: Notify nlp-engine of analyzers update
+        if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.CLASSIC_PAT }}
+          repository: VisualText/nlp-engine
+          event-type: analyzers-release
+          client-payload: '{"tag_name": "${{ steps.version.outputs.tag }}"}'
+        continue-on-error: true
+
       - name: Nothing to do
         if: steps.update.outputs.changed == 'false'
-        run: echo "${SUBMODULE} already up to date — no release created."
+        run: echo "${SUBMODULE} already up to date — no release, no downstream ping."


### PR DESCRIPTION
Patches the existing `parse-en-us.yml` so it:
- also triggers on `repository_dispatch: [parse-en-us-release]` (fired by parse-en-us's new dispatcher), defaulting the version bump to `patch` on a ping;
- after a successful release, pings **nlp-engine** (event-type `analyzers-release`) to continue the chain.

The downstream ping needs a `CLASSIC_PAT` secret in this repo.

Manual `workflow_dispatch` (with bump choice) is unchanged.